### PR TITLE
Add missing `nspr-cos6-x86_64` to `build-config.yaml`

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -26,6 +26,9 @@ recipes:
   - name: nss-cos6-x86_64
     path: nss-cos6-x86_64
 
+  - name: nspr-cos6-x86_64
+    path: nspr-cos6-x86_64
+
   - name: nss-softokn-freebl-cos6-x86_64
     path: nss-softokn-freebl-cos6-x86_64
 


### PR DESCRIPTION
This was found to be missing while implementing the config linting. open-ce/open-ce#15