### PR TITLE
point ppc64le CDTs to cos7 stable dir

### DIFF
--- a/java-1.8.0-openjdk-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-cos7-ppc64le/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.8.0.242
 
 source:
-  - url: http://mirror.centos.org/altarch/7/os/ppc64le/Packages/java-1.8.0-openjdk-1.8.0.242.b08-1.el7.ppc64le.rpm
+  - url: http://mirror.centos.org/altarch/7.8.2003/os/ppc64le/Packages/java-1.8.0-openjdk-1.8.0.242.b08-1.el7.ppc64le.rpm
     sha256: 3688da8f4ce18c99481d03f5f59bc1cad26b446bfabc64ef4373d579404526c7
     no_hoist: true
     folder: binary

--- a/java-1.8.0-openjdk-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-cos7-ppc64le/meta.yaml
@@ -10,7 +10,7 @@ source:
   - path: ../common_files
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   binary_relocation: false
   detect_binary_files_with_prefix: false

--- a/java-1.8.0-openjdk-devel-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-devel-cos7-ppc64le/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.8.0.242
 
 source:
-  - url: http://mirror.centos.org/altarch/7/os/ppc64le/Packages/java-1.8.0-openjdk-devel-1.8.0.242.b08-1.el7.ppc64le.rpm
+  - url: http://mirror.centos.org/altarch/7.8.2003/os/ppc64le/Packages/java-1.8.0-openjdk-devel-1.8.0.242.b08-1.el7.ppc64le.rpm
     sha256: 25953566448905c312a486048193cf33db283baf20cde3e0829039250394b85d
     no_hoist: true
     folder: binary

--- a/java-1.8.0-openjdk-devel-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-devel-cos7-ppc64le/meta.yaml
@@ -10,7 +10,7 @@ source:
   - path: ../common_files
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   binary_relocation: false
   detect_binary_files_with_prefix: false

--- a/java-1.8.0-openjdk-headless-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-headless-cos7-ppc64le/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.8.0.242
 
 source:
-  - url: http://mirror.centos.org/altarch/7/os/ppc64le/Packages/java-1.8.0-openjdk-headless-1.8.0.242.b08-1.el7.ppc64le.rpm
+  - url: http://mirror.centos.org/altarch/7.8.2003/os/ppc64le/Packages/java-1.8.0-openjdk-headless-1.8.0.242.b08-1.el7.ppc64le.rpm
     sha256: 6fead74097c2da68abaa84df1566a53950a805a7403f6ff2b4b00736625fdbc9
     no_hoist: true
     folder: binary

--- a/java-1.8.0-openjdk-headless-cos7-ppc64le/meta.yaml
+++ b/java-1.8.0-openjdk-headless-cos7-ppc64le/meta.yaml
@@ -10,7 +10,7 @@ source:
   - path: ../common_files
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   binary_relocation: False
   detect_binary_files_with_prefix: False

--- a/tzdata-java-cos7-ppc64le/meta.yaml
+++ b/tzdata-java-cos7-ppc64le/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 2019c
 
 source:
-  - url: http://mirror.centos.org/altarch/7/os/ppc64le/Packages/tzdata-java-2019c-1.el7.noarch.rpm
+  - url: http://mirror.centos.org/altarch/7.8.2003/os/ppc64le/Packages/tzdata-java-2019c-1.el7.noarch.rpm
     sha256: ef0c0ac7183772b70ee519f5b9c4664f37edd34d991abe4bf3c267d88cc4c253
     no_hoist: true
     folder: binary

--- a/tzdata-java-cos7-ppc64le/meta.yaml
+++ b/tzdata-java-cos7-ppc64le/meta.yaml
@@ -10,7 +10,7 @@ source:
   - path: ../common_files
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   binary_relocation: false
   detect_binary_files_with_prefix: false

--- a/zip-cos7-ppc64le/meta.yaml
+++ b/zip-cos7-ppc64le/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 3.0
 
 source:
-  - url: http://mirror.centos.org/altarch/7/os/ppc64le/Packages/zip-3.0-11.el7.ppc64le.rpm
+  - url: http://mirror.centos.org/altarch/7.8.2003/os/ppc64le/Packages/zip-3.0-11.el7.ppc64le.rpm
     sha256: 6bc905954988220bcf792d60a8c3f92bb67bb55ac266f9815de7253cd610e214
     no_hoist: true
     folder: binary

--- a/zip-cos7-ppc64le/meta.yaml
+++ b/zip-cos7-ppc64le/meta.yaml
@@ -10,7 +10,7 @@ source:
   - path: ../common_files
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   binary_relocation: false
   detect_binary_files_with_prefix: false


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes https://github.com/open-ce/open-ce/issues/174
The cos7 `7` directory is still in support and updated. Old versions are removed. The 7.8 dir has the same versions, but will stay that way.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
