### PR TITLE
Only build CDTs for the current arch

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -1,48 +1,48 @@
 recipes:
-  - name: zip-cos7-ppc64le
-    path: zip-cos7-ppc64le
+  - name: zip-cos7-ppc64le                            #[ppc64le]
+    path: zip-cos7-ppc64le                            #[ppc64le]
 
-  - name: tzdata-java-cos7-ppc64le
-    path: tzdata-java-cos7-ppc64le
+  - name: tzdata-java-cos7-ppc64le                    #[ppc64le]
+    path: tzdata-java-cos7-ppc64le                    #[ppc64le]
 
-  - name: java-1.8.0-openjdk-headless-cos7-ppc64le
-    path: java-1.8.0-openjdk-headless-cos7-ppc64le
+  - name: java-1.8.0-openjdk-headless-cos7-ppc64le    #[ppc64le]
+    path: java-1.8.0-openjdk-headless-cos7-ppc64le    #[ppc64le]
 
-  - name: java-1.8.0-openjdk-cos7-ppc64le
-    path: java-1.8.0-openjdk-cos7-ppc64le
+  - name: java-1.8.0-openjdk-cos7-ppc64le             #[ppc64le]
+    path: java-1.8.0-openjdk-cos7-ppc64le             #[ppc64le]
 
-  - name: java-1.8.0-openjdk-devel-cos7-ppc64le
-    path: java-1.8.0-openjdk-devel-cos7-ppc64le
+  - name: java-1.8.0-openjdk-devel-cos7-ppc64le       #[ppc64le]
+    path: java-1.8.0-openjdk-devel-cos7-ppc64le       #[ppc64le]
 
-  - name: tzdata-java-cos6-x86_64
-    path: tzdata-java-cos6-x86_64
+  - name: tzdata-java-cos6-x86_64                     #[x86_64]
+    path: tzdata-java-cos6-x86_64                     #[x86_64]
 
-  - name: chkconfig-cos6-x86_64
-    path: chkconfig-cos6-x86_64
+  - name: chkconfig-cos6-x86_64                       #[x86_64]
+    path: chkconfig-cos6-x86_64                       #[x86_64]
 
-  - name: nss-util-cos6-x86_64
-    path: nss-util-cos6-x86_64
+  - name: nss-util-cos6-x86_64                        #[x86_64]
+    path: nss-util-cos6-x86_64                        #[x86_64]
 
-  - name: nss-cos6-x86_64
-    path: nss-cos6-x86_64
+  - name: nss-cos6-x86_64                             #[x86_64]
+    path: nss-cos6-x86_64                             #[x86_64]
 
-  - name: nspr-cos6-x86_64
-    path: nspr-cos6-x86_64
+  - name: nspr-cos6-x86_64                            #[x86_64]
+    path: nspr-cos6-x86_64                            #[x86_64]
 
-  - name: nss-softokn-freebl-cos6-x86_64
-    path: nss-softokn-freebl-cos6-x86_64
+  - name: nss-softokn-freebl-cos6-x86_64              #[x86_64]
+    path: nss-softokn-freebl-cos6-x86_64              #[x86_64]
 
-  - name: nss-softokn-cos6-x86_64
-    path: nss-softokn-cos6-x86_64
+  - name: nss-softokn-cos6-x86_64                     #[x86_64]
+    path: nss-softokn-cos6-x86_64                     #[x86_64]
 
-  - name: copy-jdk-configs-cos6-x86_64
-    path: copy-jdk-configs-cos6-x86_64
+  - name: copy-jdk-configs-cos6-x86_64                #[x86_64]
+    path: copy-jdk-configs-cos6-x86_64                #[x86_64]
 
-  - name: java-1.8.0-openjdk-headless-cos6-x86_64
-    path: java-1.8.0-openjdk-headless-cos6-x86_64
+  - name: java-1.8.0-openjdk-headless-cos6-x86_64     #[x86_64]
+    path: java-1.8.0-openjdk-headless-cos6-x86_64     #[x86_64]
 
-  - name: java-1.8.0-openjdk-cos6-x86_64
-    path: java-1.8.0-openjdk-cos6-x86_64
+  - name: java-1.8.0-openjdk-cos6-x86_64              #[x86_64]
+    path: java-1.8.0-openjdk-cos6-x86_64              #[x86_64]
 
-  - name: java-1.8.0-openjdk-devel-cos6-x86_64
-    path: java-1.8.0-openjdk-devel-cos6-x86_64
+  - name: java-1.8.0-openjdk-devel-cos6-x86_64        #[x86_64]
+    path: java-1.8.0-openjdk-devel-cos6-x86_64        #[x86_64]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

The adds some arch switches for the config so that CDT packages are only built for the current arch.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
